### PR TITLE
Remove prepend information from asset files

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -101,14 +101,23 @@ function readPackageJSON(distPath) {
     var manifest = pkg.fastboot.manifest;
 
     return {
-      appFile: path.join(distPath, manifest.appFile),
-      vendorFile: path.join(distPath, manifest.vendorFile),
+      appFile:  path.join(distPath, removePrepend(manifest.appFile, manifest.assetPrepend)),
+      vendorFile: path.join(distPath, removePrepend(manifest.vendorFile, manifest.assetPrepend)),
       htmlFile: path.join(distPath, manifest.htmlFile),
       moduleWhitelist: pkg.fastboot.moduleWhitelist
     };
   } catch (e) {
-    console.error("Couldn't find %s. You may need to update your version of ember-cli-fastboot.", pkgPath);
+    console.log("Couldn't find %s. You may need to update your version of ember-cli-fastboot.", pkgPath);
   }
+}
+
+function removePrepend(filePath, prepend) {
+  if (prepend) {
+    var prependRegex = new RegExp('^' +  prepend);
+    filePath = filePath.replace(prependRegex, '');
+  }
+
+  return filePath;
 }
 
 module.exports = FastBootServer;


### PR DESCRIPTION
This depends on this PR, but is not blocked by: https://github.com/tildeio/ember-cli-fastboot/pull/103

This removes the domain that will be prepended to the JS assets when they are fingerprinted by broccoli-asset-rev. The PR to ember-cli-fastboot adds the information to the package.json file