### PR TITLE
Mixed issue with NPM install failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Production server for running Ember applications using FastBoot",
   "main": "./lib/server",
   "scripts": {
-    "postinstall": "scripts/is-legacy-vm && npm install contextify@^0.1.11",
+    "postinstall": "scripts/is-not-legacy-vm || npm install contextify@^0.1.11",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/scripts/is-not-legacy-vm
+++ b/scripts/is-not-legacy-vm
@@ -4,7 +4,7 @@
 var isLegacyVM = require('../lib/sandbox').isLegacyVM;
 
 if (isLegacyVM()) {
-  process.exit(0);
-} else {
   process.exit(1);
+} else {
+  process.exit(0);
 }


### PR DESCRIPTION
This puts back the contextify conditional install - but correctly .. The previous attempt had a major issue with the install script.

'is-not-legacy-vm' could do with a better name I think