### PR TITLE
Serialize head component if present

### DIFF
--- a/lib/ember-app.js
+++ b/lib/ember-app.js
@@ -60,10 +60,15 @@ EmberApp.prototype.visit = function(url) {
   var options = { isBrowser: false, document: doc, rootElement: rootElement };
 
   return this._app.visit(url, options).then(function(instance) {
+    var head;
+    if (doc.head) {
+      head = HTMLSerializer.serialize(doc.head);
+    }
     try {
       return {
         url: instance.getURL(), // TODO: use this to determine whether to 200 or redirect
         title: doc.title,
+        head: head,
         body: HTMLSerializer.serialize(rootElement) // This matches the current code; but we probably want `serializeChildren` here
       };
     } finally {

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,11 +32,14 @@ FastBootServer.prototype.log = function(statusCode, message, startTime) {
   this.ui.writeLine(chalk.blue(now.toISOString()) + " " + chalk[color](statusCode) + " " + message);
 };
 
-FastBootServer.prototype.insertIntoIndexHTML = function(title, body) {
+FastBootServer.prototype.insertIntoIndexHTML = function(title, body, head) {
   var html = this.html.replace("<!-- EMBER_CLI_FASTBOOT_BODY -->", body);
 
   if (title) {
     html = html.replace("<!-- EMBER_CLI_FASTBOOT_TITLE -->", "<title>" + title + "</title>");
+  }
+  if (head) {
+    html = html.replace("<!-- EMBER_CLI_FASTBOOT_HEAD -->", head);
   }
 
   return html;
@@ -44,7 +47,7 @@ FastBootServer.prototype.insertIntoIndexHTML = function(title, body) {
 
 FastBootServer.prototype.handleSuccess = function(res, path, result, startTime) {
   this.log(200, 'OK ' + path, startTime);
-  res.send(this.insertIntoIndexHTML(result.title, result.body));
+  res.send(this.insertIntoIndexHTML(result.title, result.body, result.head));
 };
 
 FastBootServer.prototype.handleFailure = function(res, path, error, startTime) {


### PR DESCRIPTION
To support setting head tags in a Fastboot'ed app.  Complementary ember-cli-fastboot [PR 114](https://github.com/tildeio/ember-cli-fastboot/pull/114).

Needs tests, but I think that would go into ember-cli-fastboot.