### PR TITLE
Added source-map-support library which helps with stack traces.

### DIFF
--- a/lib/ember-app.js
+++ b/lib/ember-app.js
@@ -8,6 +8,7 @@ var chalk = require('chalk');
 var najax = require('najax');
 var debug   = require('debug')('ember-cli-fastboot:ember-app');
 var emberDebug = require('debug')('ember-cli-fastboot:ember');
+var sourceMapSupport = require('./install-source-map-support');
 
 var HTMLSerializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
 
@@ -31,6 +32,9 @@ function EmberApp(options) {
     najax: najax,
     FastBoot: { require: sandboxRequire }
   });
+
+  sourceMapSupport.install(Error);
+  sandbox.run('sourceMapSupport.install(Error);');
 
   var appFile = fs.readFileSync(appFilePath, 'utf8');
   var vendorFile = fs.readFileSync(vendorFilePath, 'utf8');
@@ -86,6 +90,7 @@ function createSandbox(dependencies) {
   };
 
   var sandbox = {
+    sourceMapSupport: sourceMapSupport,
     // Expose the console to the FastBoot environment so we can debug
     console: wrappedConsole,
 

--- a/lib/install-source-map-support.js
+++ b/lib/install-source-map-support.js
@@ -1,0 +1,22 @@
+var sourceMapSupport = require('source-map-support');
+
+function prepareStackTrace(error, stack) {
+  return error + stack.map(function(frame) {
+    return '\n    at ' + sourceMapSupport.wrapCallSite(frame);
+  }).join('');
+}
+
+function install(errorClass) {
+  if (errorClass) {
+    errorClass.prepareStackTrace = prepareStackTrace;
+    errorClass.stackTraceLimit = Infinity;
+    sourceMapSupport.install({
+      environment: 'node',
+      handleUncaughtExceptions: false,
+    });
+  }
+}
+
+module.exports = {
+  install: install
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "minimist": "^1.2.0",
     "najax": "^0.3.2",
     "rsvp": "^3.0.16",
-    "simple-dom": "^0.2.7"
+    "simple-dom": "^0.2.7",
+    "source-map-support": "^0.4.0"
   }
 }


### PR DESCRIPTION
This library needs some assistance to attach to `Error.prepareStackTrace` outside the VM then again inside the VM. Internally it keeps track of a `errorFormatterInstalled` flag - this flag stops any future calls to install on `Error.prepareStackTrace` after the first one, which is usually the one outside the VM.