### PR TITLE
Retain query params when routing

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -76,7 +76,7 @@ FastBootServer.prototype.handleAppBootFailure = function(error) {
 
 FastBootServer.prototype.middleware = function() {
   return function(req, res, next) {
-    var path = req.path;
+    var path = req.url;
     debug("middleware request; path=%s", path);
 
     var server = this;


### PR DESCRIPTION
This commit fixes a bug where query params were inadvertently dropped
from the incoming request when routing in Ember.

See https://github.com/tildeio/ember-cli-fastboot/issues/53