### PR TITLE
Fix Nested body & head

### DIFF
--- a/lib/ember-app.js
+++ b/lib/ember-app.js
@@ -119,7 +119,7 @@ function serializeHTML(doc, rootElement) {
     var head;
 
     if (doc.head) {
-      head = HTMLSerializer.serialize(doc.head);
+      head = HTMLSerializer.serializeChildren(doc.head);
     }
 
     try {
@@ -127,7 +127,7 @@ function serializeHTML(doc, rootElement) {
         url: instance.getURL(), // TODO: use this to determine whether to 200 or redirect
         title: doc.title,
         head: head,
-        body: HTMLSerializer.serialize(rootElement) // This matches the current code; but we probably want `serializeChildren` here
+        body: HTMLSerializer.serializeChildren(rootElement)
       };
     } finally {
       instance.destroy();

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "minimist": "^1.2.0",
     "najax": "^0.4.0",
     "rsvp": "^3.0.16",
-    "simple-dom": "^0.2.7",
+    "simple-dom": "^0.3.0",
     "source-map-support": "^0.4.0"
   },
   "devDependencies": {

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -32,6 +32,23 @@ describe("bin/ember-fastboot", function() {
       });
   });
 
+  it("has 1 body tag", function() {
+    this.timeout(3000);
+
+    var server = new Server('basic-app');
+
+    return expect(server.start()).to.be.fulfilled
+      .then(function() {
+        return request('http://localhost:3000');
+      })
+      .then(function(html) {
+        expect(html.match(/<body>/g)).have.length(1);
+      })
+      .finally(function() {
+        server.stop();
+      });
+  });
+
   it("serves assets if the --serve-assets-from option is provided", function() {
     this.timeout(3000);
 


### PR DESCRIPTION
Use simple-dom's `serializeChildren` method to serialize the contents of head & body tags for substitution into index.html.  

Fixes #30 