### PR TITLE
setup express-cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - "0.11"
   - "0.10"
 env:
-  - CXX=g++-4.8
+  - CXX=g++-4.8 WORKER_COUNT=2
 addons:
   apt:
     sources:

--- a/bin/ember-fastboot
+++ b/bin/ember-fastboot
@@ -6,6 +6,7 @@ process.title = 'ember-fastboot-server';
 
 var FastBootServer = require('../lib/server');
 var express = require('express');
+var cluster = require('express-cluster');
 var parseArgs = require('minimist');
 
 var argOptions = {
@@ -36,25 +37,26 @@ console.log('Booting Ember app...');
 // go through more churn in the near term.
 server.app.buildApp().then(function() {
   console.log('Ember app booted successfully.');
+  cluster(function() {
+    var app = express();
 
-  var app = express();
+    if (assetPath) {
+      app.get('/', server.middleware());
+      app.use(express.static(assetPath));
+    }
 
-  if (assetPath) {
-    app.get('/', server.middleware());
-    app.use(express.static(assetPath));
-  }
+    app.get('/*', server.middleware());
 
-  app.get('/*', server.middleware());
+    var listener = app.listen(options.port, options.host, function() {
+      var host = listener.address().address;
+      var port = listener.address().port;
+      var family = listener.address().family;
 
-  var listener = app.listen(options.port, options.host, function() {
-    var host = listener.address().address;
-    var port = listener.address().port;
-    var family = listener.address().family;
+      if (family === 'IPv6') { host = '[' + host + ']'; }
 
-    if (family === 'IPv6') { host = '[' + host + ']'; }
-
-    console.log('Ember FastBoot running at http://' + host + ":" + port);
-  });
+      console.log('Ember FastBoot running at http://' + host + ":" + port);
+    });
+  }, { verbose: true });
 }, function(error) {
   if (error.stack) {
     console.error('An error occured when booting Ember app...');

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cookie": "^0.2.3",
     "debug": "^2.1.0",
     "express": "^4.13.3",
+    "express-cluster": "0.0.4",
     "glob": "^4.0.5",
     "minimist": "^1.2.0",
     "najax": "^0.4.0",


### PR DESCRIPTION
Setup express cluster to have a more performant backend server. You can use the env var `WORKER_COUNT` to setup number of workers. By default, it'll use the detected number of CPUs.