### PR TITLE
Remove hard contextify dependency

### DIFF
--- a/lib/ember-app.js
+++ b/lib/ember-app.js
@@ -1,13 +1,11 @@
 var fs = require('fs');
 var path = require('path');
 
-var Contextify = require('contextify');
 var SimpleDOM = require('simple-dom');
-var chalk = require('chalk');
 var najax = require('najax');
 var debug   = require('debug')('ember-cli-fastboot:ember-app');
-var sourceMapSupport = require('./install-source-map-support');
 var FastBootInfo = require('./fastboot-info');
+var Sandbox = require('./sandbox');
 
 var HTMLSerializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
 
@@ -28,24 +26,27 @@ function EmberApp(options) {
   // Create the sandbox, giving it the resolver to resolve once the app
   // has booted.
   var sandboxRequire = buildWhitelistedRequire(moduleWhitelist, distPath);
-  var sandbox = createSandbox({
-    najax: najax,
-    FastBoot: { require: sandboxRequire }
+  var sandbox = new Sandbox({
+    globals: {
+      najax: najax,
+      FastBoot: { require: sandboxRequire }
+    }
   });
 
-  sourceMapSupport.install(Error);
-  sandbox.run('sourceMapSupport.install(Error);');
+  sandbox.eval('sourceMapSupport.install(Error);');
 
   var appFile = fs.readFileSync(appFilePath, 'utf8');
   var vendorFile = fs.readFileSync(vendorFilePath, 'utf8');
 
-  sandbox.run(vendorFile, vendorFilePath);
+  sandbox.eval(vendorFile, vendorFilePath);
   debug("vendor file evaluated");
 
-  sandbox.run(appFile, appFilePath);
+  sandbox.eval(appFile, appFilePath);
   debug("app file evaluated");
 
-  var AppFactory = sandbox.require('~fastboot/app-factory');
+  var AppFactory = sandbox.run(function(ctx) {
+    return ctx.require('~fastboot/app-factory');
+  });
 
   if (!AppFactory || typeof AppFactory['default'] !== 'function') {
     throw new Error('Failed to load Ember app from ' + appFilePath + ', make sure it was built for FastBoot with the `ember fastboot:build` command.');
@@ -133,43 +134,6 @@ function serializeHTML(doc, rootElement) {
       instance.destroy();
     }
   };
-}
-
-function createSandbox(dependencies) {
-  var wrappedConsole =  Object.create(console);
-  wrappedConsole.error = function() {
-    console.error.apply(console, Array.prototype.map.call(arguments, function(a) {
-      return typeof a === 'string' ? chalk.red(a) : a;
-    }));
-  };
-
-  var sandbox = {
-    sourceMapSupport: sourceMapSupport,
-    // Expose the console to the FastBoot environment so we can debug
-    console: wrappedConsole,
-
-    // setTimeout and clearTimeout are an assumed part of JavaScript environments. Expose it.
-    setTimeout: setTimeout,
-    clearTimeout: clearTimeout,
-
-    // Convince jQuery not to assume it's in a browser
-    module: { exports: {} },
-
-    URL: require("url")
-  };
-
-  for (var dep in dependencies) {
-    sandbox[dep] = dependencies[dep];
-  }
-
-  // Set the global as `window`.
-  sandbox.window = sandbox;
-  sandbox.window.self = sandbox;
-
-  // The sandbox is now a JavaScript context O_o
-  Contextify(sandbox);
-
-  return sandbox;
 }
 
 function buildWhitelistedRequire(whitelist, distPath) {

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -1,0 +1,64 @@
+var chalk = require('chalk');
+
+function isLegacyVM() {
+  return require('vm').isContext === undefined;
+}
+
+function Sandbox(options) {
+  var klass;
+
+  if (isLegacyVM()) {
+    klass = require('./sandboxes/contextify');
+  } else {
+    klass = require('./sandboxes/vm');
+  }
+
+  return new klass(options);
+}
+
+Sandbox.prototype.init = function(options) {
+  this.globals = options.globals;
+  this.sandbox = this.buildSandbox();
+};
+
+Sandbox.prototype.buildSandbox = function() {
+  var console = this.buildWrappedConsole();
+  var sourceMapSupport = require('./install-source-map-support');
+  var URL = require('url');
+  var globals = this.globals;
+
+  var sandbox = {
+    sourceMapSupport: sourceMapSupport,
+    console: console,
+    setTimeout: setTimeout,
+    clearTimeout: clearTimeout,
+    URL: URL,
+
+    // Convince jQuery not to assume it's in a browser
+    module: { exports: {} }
+  };
+
+  for (var key in globals) {
+    sandbox[key] = globals[key];
+  }
+
+  // Set the global as `window`.
+  sandbox.window = sandbox;
+  sandbox.window.self = sandbox;
+
+  return sandbox;
+};
+
+Sandbox.prototype.buildWrappedConsole = function() {
+  var wrappedConsole =  Object.create(console);
+  wrappedConsole.error = function() {
+    console.error.apply(console, Array.prototype.map.call(arguments, function(a) {
+      return typeof a === 'string' ? chalk.red(a) : a;
+    }));
+  };
+
+}
+
+Sandbox.isLegacyVM = isLegacyVM;
+
+module.exports = Sandbox;

--- a/lib/sandboxes/contextify.js
+++ b/lib/sandboxes/contextify.js
@@ -1,0 +1,21 @@
+var Contextify = require('contextify');
+var Sandbox = require('../sandbox');
+
+function ContextifySandbox(options) {
+  this.init(options);
+  Contextify(this.sandbox);
+}
+
+ContextifySandbox.prototype = Object.create(Sandbox.prototype);
+ContextifySandbox.prototype.constructor = Sandbox;
+
+ContextifySandbox.prototype.eval = function(source, filePath) {
+  this.sandbox.run(source, filePath);
+};
+
+ContextifySandbox.prototype.run = function(cb) {
+  var sandbox = this.sandbox;
+  return cb.call(sandbox, sandbox);
+};
+
+module.exports = ContextifySandbox;

--- a/lib/sandboxes/vm.js
+++ b/lib/sandboxes/vm.js
@@ -1,0 +1,21 @@
+var vm = require('vm');
+var Sandbox = require('../sandbox');
+
+function VMSandbox(options) {
+  this.init(options);
+  vm.createContext(this.sandbox);
+}
+
+VMSandbox.prototype = Object.create(Sandbox.prototype);
+VMSandbox.prototype.constructor = Sandbox;
+
+VMSandbox.prototype.eval = function(source, filePath) {
+  var fileScript = new vm.Script(source, { filename: filePath });
+  fileScript.runInContext(this.sandbox);
+};
+
+VMSandbox.prototype.run = function(cb) {
+  return cb.call(this.sandbox, this.sandbox);
+};
+
+module.exports = VMSandbox;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Production server for running Ember applications using FastBoot",
   "main": "./lib/server",
   "scripts": {
+    "postinstall": "scripts/is-not-legacy-vm || npm install contextify@^0.1.11",
     "test": "mocha"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/ember-fastboot/ember-fastboot-server#readme",
   "dependencies": {
     "chalk": "^0.5.1",
-    "contextify": "^0.1.11",
     "cookie": "^0.2.3",
     "debug": "^2.1.0",
     "express": "^4.13.3",

--- a/scripts/is-not-legacy-vm
+++ b/scripts/is-not-legacy-vm
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+"use strict";
+
+var isLegacyVM = require('../lib/sandbox').isLegacyVM;
+
+if (isLegacyVM()) {
+  process.exit(1);
+} else {
+  process.exit(0);
+}

--- a/test/helpers/cli-server.js
+++ b/test/helpers/cli-server.js
@@ -32,12 +32,12 @@ Server.prototype.start = function() {
     });
 
     server.on('exit', function(statusCode, signal) {
-      if (signal === 'SIGTERM') {
+      if (signal === 'SIGTERM' || statusCode === 143) {
         resolve();
         return;
       }
 
-      console.error('Server exited unexpectedly');
+      console.error('Server exited unexpectedly: ' + signal + ' ' + statusCode);
       reject();
     });
   });


### PR DESCRIPTION
This is based on @jmurphyau’s previous work, but updated to use subclasses. Hopefully in the future we can make this pluggable.

This detects if the current version of Node being used supports newer `vm` features, and if so, skips installing `contextify`.