### PR TITLE
[MINOR]: Fix "main" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ember-fastboot-server",
   "version": "0.5.4",
   "description": "Production server for running Ember applications using FastBoot",
-  "main": "./lib/server",
+  "main": "./lib",
   "scripts": {
     "postinstall": "scripts/is-not-legacy-vm || npm install contextify@^0.1.11",
     "test": "mocha"


### PR DESCRIPTION
While looking at ember-fastboot-server for sandbox reuse, I realized the entry point of this package was incorrect. There is no `./lib/server` anymore. So I changed it to point to the `lib` folder.

I did not add any tests since this was more of a cleanup.