### PR TITLE
Provide FastBootRequest object to FastBootInfo

### DIFF
--- a/lib/fastboot-headers.js
+++ b/lib/fastboot-headers.js
@@ -1,0 +1,25 @@
+// Partially implements Headers from the Fetch API
+// https://developer.mozilla.org/en-US/docs/Web/API/Headers
+function FastBootHeaders(headers) {
+  this.headers = headers
+}
+
+FastBootHeaders.prototype.get = function(header) {
+  return this.getAll(header)[0] || null;
+}
+
+FastBootHeaders.prototype.getAll = function(header) {
+  var headerValue = this.headers[header.toLowerCase()];
+
+  if (headerValue) {
+    return headerValue.split(', ');
+  }
+
+  return [];
+}
+
+FastBootHeaders.prototype.has = function(header) {
+  return this.headers[header.toLowerCase()] !== undefined;
+}
+
+module.exports = FastBootHeaders;

--- a/lib/fastboot-info.js
+++ b/lib/fastboot-info.js
@@ -1,4 +1,4 @@
-var cookie = require('cookie');
+var FastBootRequest = require('./fastboot-request');
 
 /*
  * A class that encapsulates information about the
@@ -6,56 +6,9 @@ var cookie = require('cookie');
  * on to the FastBoot service.
  */
 function FastBootInfo(request, response, hostWhitelist) {
-  this.request = request;
   this.response = response;
-
-  this.cookies = this.extractCookies(request);
-  this.headers = request.headers;
-  this.hostWhitelist = hostWhitelist;
+  this.request = new FastBootRequest(request, hostWhitelist);
 }
-
-FastBootInfo.prototype.extractCookies = function(request) {
-  // If cookie-parser middleware has already parsed the cookies,
-  // just use that.
-  if (request.cookies) {
-    return request.cookies;
-  }
-
-  // Otherwise, try to parse the cookies ourselves, if they exist.
-  var cookies = request.get('cookie');
-  if (cookies) {
-    return cookie.parse(cookies);
-  }
-
-  // Return an empty object instead of undefined if no cookies are present.
-  return {};
-};
-
-FastBootInfo.prototype.host = function() {
-  if (!this.hostWhitelist) {
-    throw new Error('You must provide a hostWhitelist to retrieve the host');
-  }
-
-  var host = this.request.headers.host;
-
-  var matchFound = this.hostWhitelist.reduce(function(previous, currentEntry) {
-    if (currentEntry[0] === '/' &&
-        currentEntry.slice(-1) === '/') {
-      // RegExp as string
-      var regexp = new RegExp(currentEntry.slice(1, -1));
-
-      return previous || regexp.test(host);
-    } else {
-      return previous || currentEntry === host;
-    }
-  }, false);
-
-  if (!matchFound) {
-    throw new Error('The host header did not match a hostWhitelist entry');
-  }
-
-  return this.request.protocol + '://' + host;
-};
 
 /*
  * Registers this FastBootInfo instance in the registry of an Ember

--- a/lib/fastboot-request.js
+++ b/lib/fastboot-request.js
@@ -1,0 +1,58 @@
+var cookie = require('cookie');
+var FastBootHeaders = require('./fastboot-headers');
+
+function FastBootRequest(request, hostWhitelist) {
+  this.hostWhitelist = hostWhitelist;
+
+  this.protocol = request.protocol
+  this.headers = new FastBootHeaders(request.headers);
+  this.queryParams = request.query;
+  this.path = request.url;
+
+  this.cookies = this.extractCookies(request);
+}
+
+FastBootRequest.prototype.host = function() {
+  if (!this.hostWhitelist) {
+    throw new Error('You must provide a hostWhitelist to retrieve the host');
+  }
+
+  var host = this.headers.get('host');
+
+  var matchFound = this.hostWhitelist.reduce(function(previous, currentEntry) {
+    if (currentEntry[0] === '/' &&
+        currentEntry.slice(-1) === '/') {
+      // RegExp as string
+      var regexp = new RegExp(currentEntry.slice(1, -1));
+
+      return previous || regexp.test(host);
+    } else {
+      return previous || currentEntry === host;
+    }
+  }, false);
+
+  if (!matchFound) {
+    throw new Error('The host header did not match a hostWhitelist entry');
+  }
+
+  return host;
+};
+
+FastBootRequest.prototype.extractCookies = function(request) {
+  // If cookie-parser middleware has already parsed the cookies,
+  // just use that.
+  if (request.cookies) {
+    return request.cookies;
+  }
+
+  // Otherwise, try to parse the cookies ourselves, if they exist.
+  var cookies = request.get('cookie');
+  if (cookies) {
+    return cookie.parse(cookies);
+  }
+
+  // Return an empty object instead of undefined if no cookies are present.
+  return {};
+};
+
+module.exports = FastBootRequest;

--- a/test/fastboot-headers-test.js
+++ b/test/fastboot-headers-test.js
@@ -1,0 +1,68 @@
+var expect = require('chai').expect;
+var path = require('path');
+var FastBootHeaders = require('../lib/fastboot-headers.js');
+
+describe('FastBootHeaders', function() {
+  it('returns an array of header values from getAll, regardless of header name casing', function() {
+    var headers = {
+      // Express concatenates repeated keys with ', '
+      // and also lowercases the keys
+      'x-test-header': 'value1, value2'
+    };
+    var headers = new FastBootHeaders(headers);
+
+    expect(headers.getAll('X-Test-Header')).to.deep.equal(['value1', 'value2']);
+    expect(headers.getAll('x-test-header')).to.deep.equal(['value1', 'value2']);
+  });
+
+  it('returns an emtpy array when a header is not present', function() {
+    var headers = {
+      // Express concatenates repeated keys with ', '
+      // and also lowercases the keys
+      'x-test-header': 'value1, value2'
+    };
+    var headers = new FastBootHeaders(headers);
+
+    expect(headers.getAll('Host')).to.deep.equal([]);
+    expect(headers.getAll('host')).to.deep.equal([]);
+  });
+
+  it('returns the first value when using get, regardless of case', function() {
+    var headers = {
+      // Express concatenates repeated keys with ', '
+      // and also lowercases the keys
+      "x-test-header": "value1, value2"
+    };
+    var headers = new FastBootHeaders(headers);
+
+    expect(headers.get('X-Test-Header')).to.equal('value1');
+    expect(headers.get('x-test-header')).to.equal('value1');
+  });
+
+  it('returns null when using get when a header is not present', function() {
+    var headers = {
+      // Express concatenates repeated keys with ', '
+      // and also lowercases the keys
+      "x-test-header": "value1, value2"
+    };
+    var headers = new FastBootHeaders(headers);
+
+    expect(headers.get('Host')).to.be.null;
+    expect(headers.get('host')).to.be.null;
+  });
+
+  it('returns whether or not a header is present via has, regardless of case', function() {
+    var headers = {
+      // Express concatenates repeated keys with ', '
+      // and also lowercases the keys
+      "x-test-header": "value1, value2"
+    };
+    var headers = new FastBootHeaders(headers);
+
+    expect(headers.has('X-Test-Header')).to.be.true;
+    expect(headers.has('x-test-header')).to.be.true;
+    expect(headers.has('Host')).to.be.false;
+    expect(headers.has('host')).to.be.false;
+  });
+});
+

--- a/test/fastboot-info-test.js
+++ b/test/fastboot-info-test.js
@@ -3,7 +3,7 @@ var path = require('path');
 var FastBootInfo = require('../lib/fastboot-info.js');
 
 describe("FastBootInfo", function() {
-  it("throws an exception if no hostWhitelist is provided", function() {
+  it("has a FastBootRequest", function() {
     var response = {};
     var request = {
       cookie: "",
@@ -14,71 +14,9 @@ describe("FastBootInfo", function() {
         return this.cookie;
       }
     };
-    var fastBootInfo = new FastBootInfo(request, response);
+    var fastbootInfo = new FastBootInfo(request, response);
 
-    var fn = function() {
-      fastBootInfo.host();
-    };
-    expect(fn).to.throw(/You must provide a hostWhitelist to retrieve the host/);
-  });
-
-  it("throws an exception if the host header does not match an entry in the hostWhitelist", function() {
-    var response = {};
-    var request = {
-      cookie: "",
-      protocol: "http",
-      headers: {
-        host: "evil.com"
-      },
-      get: function() {
-        return this.cookie;
-      }
-    };
-    var hostWhitelist = ["example.com", "localhost:4200"]
-    var fastBootInfo = new FastBootInfo(request, response, hostWhitelist);
-
-    var fn = function() {
-      fastBootInfo.host();
-    };
-    expect(fn).to.throw(/The host header did not match a hostWhitelist entry/);
-  });
-
-  it("returns the host with protocol if it is in the hostWhitelist", function() {
-    var response = {};
-    var request = {
-      cookie: "",
-      protocol: "http",
-      headers: {
-        host: "localhost:4200"
-      },
-      get: function() {
-        return this.cookie;
-      }
-    };
-    var hostWhitelist = ["example.com", "localhost:4200"]
-    var fastBootInfo = new FastBootInfo(request, response, hostWhitelist);
-
-    var host =  fastBootInfo.host();
-    expect(host).to.equal("http://localhost:4200");
-  });
-
-  it("returns the host with protocol matches a regex in the hostWhitelist", function() {
-    var response = {};
-    var request = {
-      cookie: "",
-      protocol: "http",
-      headers: {
-        host: "localhost:4200"
-      },
-      get: function() {
-        return this.cookie;
-      }
-    };
-    var hostWhitelist = ["example.com", "/localhost:\\d+/"]
-    var fastBootInfo = new FastBootInfo(request, response, hostWhitelist);
-
-    var host =  fastBootInfo.host();
-    expect(host).to.equal("http://localhost:4200");
+    expect(fastbootInfo.request.protocol).to.equal("http");
   });
 });
 

--- a/test/fastboot-request-test.js
+++ b/test/fastboot-request-test.js
@@ -1,0 +1,165 @@
+var expect = require('chai').expect;
+var path = require('path');
+var FastBootRequest = require('../lib/fastboot-request.js');
+
+describe("FastBootRequest", function() {
+  it("throws an exception if no hostWhitelist is provided", function() {
+    var request = {
+      cookie: "",
+      protocol: "http",
+      headers: {
+      },
+      get: function() {
+        return this.cookie;
+      }
+    };
+    var fastbootRequest = new FastBootRequest(request);
+
+    var fn = function() {
+      fastbootRequest.host();
+    };
+    expect(fn).to.throw(/You must provide a hostWhitelist to retrieve the host/);
+  });
+
+  it("throws an exception if the host header does not match an entry in the hostWhitelist", function() {
+    var request = {
+      cookie: "",
+      protocol: "http",
+      headers: {
+        host: "evil.com"
+      },
+      get: function() {
+        return this.cookie;
+      }
+    };
+    var hostWhitelist = ["example.com", "localhost:4200"]
+    var fastbootRequest = new FastBootRequest(request, hostWhitelist);
+
+    var fn = function() {
+      fastbootRequest.host();
+    };
+    expect(fn).to.throw(/The host header did not match a hostWhitelist entry/);
+  });
+
+  it("returns the host if it is in the hostWhitelist", function() {
+    var request = {
+      cookie: "",
+      protocol: "http",
+      headers: {
+        host: "localhost:4200"
+      },
+      get: function() {
+        return this.cookie;
+      }
+    };
+    var hostWhitelist = ["example.com", "localhost:4200"]
+    var fastbootRequest = new FastBootRequest(request, hostWhitelist);
+
+    var host =  fastbootRequest.host();
+    expect(host).to.equal("localhost:4200");
+  });
+
+  it("returns the host if it matches a regex in the hostWhitelist", function() {
+    var request = {
+      cookie: "",
+      protocol: "http",
+      headers: {
+        host: "localhost:4200"
+      },
+      get: function() {
+        return this.cookie;
+      }
+    };
+    var hostWhitelist = ["example.com", "/localhost:\\d+/"]
+    var fastbootRequest = new FastBootRequest(request, hostWhitelist);
+
+    var host =  fastbootRequest.host();
+    expect(host).to.equal("localhost:4200");
+  });
+
+  it("captures the query params from the request", function() {
+    var request = {
+      cookie: "",
+      protocol: "http",
+      query: {
+        foo: "bar"
+      },
+      get: function() {
+        return this.cookie;
+      }
+    };
+    var fastbootRequest = new FastBootRequest(request);
+
+    expect(fastbootRequest.queryParams.foo).to.equal("bar");
+  });
+
+  it("captures the path from the request", function() {
+    var request = {
+      cookie: "",
+      protocol: "http",
+      url: "/foo",
+
+      get: function() {
+        return this.cookie;
+      }
+    };
+    var fastbootRequest = new FastBootRequest(request);
+
+    expect(fastbootRequest.path).to.equal("/foo");
+  });
+
+  it("captures the headers from the request", function() {
+    var request = {
+      cookie: "",
+      protocol: "http",
+      url: "/foo",
+      headers: {
+        host: "localhost:4200"
+      },
+
+      get: function() {
+        return this.cookie;
+      }
+    };
+    var fastbootRequest = new FastBootRequest(request);
+
+    expect(fastbootRequest.headers.get('Host')).to.equal("localhost:4200");
+  });
+
+  it("captures the protocol from the request", function() {
+    var request = {
+      cookie: "",
+      protocol: "http",
+      url: "/foo",
+      headers: {
+        host: "localhost:4200"
+      },
+
+      get: function() {
+        return this.cookie;
+      }
+    };
+    var fastbootRequest = new FastBootRequest(request);
+
+    expect(fastbootRequest.protocol).to.equal("http");
+  });
+
+  it("captures the cookies from the request", function() {
+    var request = {
+      cookie: "test=bar",
+      protocol: "http",
+      url: "/foo",
+      headers: {
+        host: "localhost:4200"
+      },
+
+      get: function() {
+        return this.cookie;
+      }
+    };
+    var fastbootRequest = new FastBootRequest(request);
+
+    expect(fastbootRequest.cookies.test).to.equal("bar");
+  });
+});
+


### PR DESCRIPTION
Capture query params and path off the request

I think we may want to remove `FastBootInfo.request` and replace it with an object that we build ourselves. In that effort, `FastBootInfo.{cookies,headers}` would belong in that `request` object. This would obviously change the API here and should likely be mirrored in `ember-cli-fastboot` (with proper deprecation warnings)

~~This PR is made without doing the above, storing the query params and path on the `FastBootInfo` root~~

@tomdale Thoughts on this?