### PR TITLE
Drop support for Node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - "4.0"
   - "0.12"
   - "0.11"
-  - "0.10"
 env:
   - CXX=g++-4.8 WORKER_COUNT=2
 addons:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ prerequisite for developing FastBoot apps.
 
 [ember-cli-fastboot]: https://github.com/tildeio/ember-cli-fastboot
 
+The FastBoot server requires Node 0.12 or later.
+
 ## Usage
 
 ### Command Line

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,8 @@ var util     = require('util');
 var EmberApp = require('./ember-app');
 var debug    = require('debug')('ember-cli-fastboot:server');
 
+detectDeprecatedNode();
+
 function FastBootServer(options) {
   options = options || {};
 
@@ -144,6 +146,17 @@ function readPackageJSON(distPath) {
     moduleWhitelist: pkg.fastboot.moduleWhitelist,
     hostWhitelist: pkg.fastboot.hostWhitelist
   };
+}
+
+function detectDeprecatedNode() {
+  var version = process.version.match(/^v(\d+)\.(\d+)/);
+
+  var major = parseInt(version[1]);
+  var minor = parseInt(version[2]);
+
+  if (major === 0 && minor <= 10) {
+    console.log("Support for Node.js 0.10 has been deprecated and will be removed before the 1.0 release. Please upgrade to Node.js 0.12 or later.");
+  }
 }
 
 module.exports = FastBootServer;


### PR DESCRIPTION
This PR removes official support for Node.js 0.10.

I am not explicitly removing the `contextify` sandbox adapter for now, but will issue a deprecation warning and remove 0.10 from the test matrix. Before 1.0, I'll remove support entirely. We can add the option to override the sandbox in the future if people want to maintain 0.10 (or other sandbox) support themselves.