### PR TITLE
FastBootWatcher (ember-fastboot --watch)

### DIFF
--- a/bin/ember-fastboot
+++ b/bin/ember-fastboot
@@ -10,6 +10,9 @@ var expressCluster = require('express-cluster');
 var cluster = require('cluster');
 var parseArgs = require('minimist');
 
+var FastBootWatcher = require('../lib/watcher');
+var debounce = require('lodash.debounce');
+
 var argOptions = {
   default: { port: 3000, host: '::' }
 };
@@ -17,6 +20,7 @@ var argOptions = {
 var options = parseArgs(process.argv.slice(2), argOptions);
 var distPath = options._[0];
 var assetPath = options['serve-assets-from'];
+var enableWatcher = options['watch'];
 
 if (!distPath) {
   console.error("You must call ember-fastboot with the path of a fastboot-dist directory:\n\n" +
@@ -74,20 +78,36 @@ server.app.buildApp().then(function() {
   process.exit(1);
 });
 
+var reloadCluster = function() {
+  console.log('Reloading Ember app from ' + distPath);
+
+  server.reload();
+
+  for (var id in cluster.workers) {
+    cluster.workers[id].send({ event: 'fastboot-reload' });
+  }
+};
+
 if (cluster.isMaster) {
-  process.on('SIGUSR1', function() {
-    console.log('Reloading Ember app from ' + distPath);
-
-    server.reload();
-
-    for (var id in cluster.workers) {
-      cluster.workers[id].send({ event: 'fastboot-reload' });
-    }
-  });
+  process.on('SIGUSR1', reloadCluster);
 } else {
   process.on('message', function(message) {
     if (message.event === 'fastboot-reload') {
       server.reload();
     }
   });
+}
+
+if (enableWatcher && cluster.isMaster) {
+  var scheduleReload = debounce(function() {
+    reloadCluster();
+  }, 100);
+
+  var watcher = new FastBootWatcher({
+    watchedDir: distPath
+  });
+
+  watcher.on('change', scheduleReload);
+  watcher.on('add', scheduleReload);
+  watcher.on('delete', scheduleReload);
 }

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var Sane = require('sane');
+
+var defaultUI = {
+  writeLine: function() {
+    console.log.apply(console, arguments);
+  }
+};
+
+function FastBootWatcher(options) {
+  options = options || {};
+
+  this.watchedDir = options.watchedDir;
+  this.ui = options.ui || this.ui || defaultUI;
+  this.verbose = options.verbose;
+
+  console.log('FastBootWatcher watching', this.watchedDir);
+
+  this.watcher = this.watcher || new Sane(this.watchedDir, {
+    verbose: this.verbose
+  });
+
+  this.watcher.on('change', this.didChange.bind(this));
+  this.watcher.on('add',    this.didAdd.bind(this));
+  this.watcher.on('delete', this.didDelete.bind(this));
+};
+
+FastBootWatcher.prototype.didChange = function(filepath) {
+  this.ui.writeLine('Server file changed: ' + filepath);
+};
+
+FastBootWatcher.prototype.didAdd = function(filepath) {
+  this.ui.writeLine('Server file added: ' + filepath);
+};
+
+FastBootWatcher.prototype.didDelete = function(filepath) {
+  this.ui.writeLine('Server file deleted: ' + filepath);
+};
+
+FastBootWatcher.prototype.on = function() {
+  this.watcher.on.apply(this.watcher, arguments);
+};
+
+FastBootWatcher.prototype.off = function() {
+  this.watcher.off.apply(this.watcher, arguments);
+};
+
+module.exports = FastBootWatcher;

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
     "express": "^4.13.3",
     "express-cluster": "0.0.4",
     "glob": "^4.0.5",
+    "lodash.debounce": "^4.0.6",
     "minimist": "^1.2.0",
     "najax": "^0.4.0",
     "rsvp": "^3.0.16",
+    "sane": "^1.1.1",
     "simple-dom": "^0.3.0",
     "source-map-support": "^0.4.0"
   },

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -95,34 +95,66 @@ describe("bin/ember-fastboot", function() {
     var tmpPath = temp.path({ suffix: '-fastboot-server-test' });
     var server = new Server({ path: tmpPath });
 
-    after(function() {
-      server.stop();
+    return expect(fsp.copy(fixturePath('basic-app'), tmpPath)).to.be.fulfilled
+      .then(function() {
+        return server.start()
+          .then(function() {
+            return request('http://localhost:3000');
+          })
+          .then(function(html) {
+            expect(html).to.match(/<h2 id="title">Welcome to Ember<\/h2>/);
+          })
+          .then(function() {
+            return fsp.remove(tmpPath);
+          })
+          .then(function() {
+            return fsp.copy(fixturePath('hot-swap-app'), tmpPath);
+          })
+          .then(function() {
+            return server.reload();
+          })
+          .then(function() {
+            return request('http://localhost:3000');
+          })
+          .then(function(html) {
+            expect(html).to.match(/<h2 id="title">Goodbye from Ember<\/h2>/);
+          })
+          .finally(function() {
+            server.stop();
+          });
+      });
+  });
+
+  it("reloads on file changes if the --watch option is provided", function() {
+    this.timeout(7000);
+
+    var tmpPath = temp.path({ suffix: '-fastboot-server-test' });
+    var server = new Server({
+      path: tmpPath,
+      args: ['--watch']
     });
 
     return expect(fsp.copy(fixturePath('basic-app'), tmpPath)).to.be.fulfilled
       .then(function() {
-        return server.start();
-      })
-      .then(function() {
-        return request('http://localhost:3000');
-      })
-      .then(function(html) {
-        expect(html).to.match(/<h2 id="title">Welcome to Ember<\/h2>/);
-      })
-      .then(function() {
-        return fsp.remove(tmpPath);
-      })
-      .then(function() {
-        return fsp.copy(fixturePath('hot-swap-app'), tmpPath);
-      })
-      .then(function() {
-        return server.reload();
-      })
-      .then(function() {
-        return request('http://localhost:3000');
-      })
-      .then(function(html) {
-        expect(html).to.match(/<h2 id="title">Goodbye from Ember<\/h2>/);
+        return server.start()
+          .then(function() {
+            return request('http://localhost:3000');
+          })
+          .then(function(html) {
+            expect(html).to.match(/<h2 id="title">Welcome to Ember<\/h2>/);
+          })
+          .then(function() {
+            return fsp.copy(fixturePath('hot-swap-app'), tmpPath);
+          })
+          .then(function() {
+            return request('http://localhost:3000');
+          })
+          .then(function(html) {
+            expect(html).to.match(/<h2 id="title">Goodbye from Ember<\/h2>/);
+          })
+          .finally(function() {
+            server.stop();
+          });
       });
   });
 });

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -131,6 +131,7 @@ describe("bin/ember-fastboot", function() {
     var tmpPath = temp.path({ suffix: '-fastboot-server-test' });
     var server = new Server({
       path: tmpPath,
+      // verbose: true,
       args: ['--watch']
     });
 
@@ -145,6 +146,15 @@ describe("bin/ember-fastboot", function() {
           })
           .then(function() {
             return fsp.copy(fixturePath('hot-swap-app'), tmpPath);
+          })
+          .then(function() {
+            return new RSVP.Promise(function(resolve) {
+              server.stdout.on('data', function(data) {
+                if (data.toString().match('Reloading Ember app')) {
+                  resolve();
+                }
+              });
+            });
           })
           .then(function() {
             return request('http://localhost:3000');

--- a/test/helpers/cli-server.js
+++ b/test/helpers/cli-server.js
@@ -13,6 +13,7 @@ function Server(fixture, options) {
 
   this.path = options.path || fixturePath(fixture);
   this.args = [this.path];
+  this.verbose = options.verbose;
 
   if (options.args) {
     this.args = this.args.concat(options.args);
@@ -21,9 +22,19 @@ function Server(fixture, options) {
 
 Server.prototype.start = function() {
   var server = this.server = childProcess.spawn(binPath, this.args);
+  var verbose = this.verbose;
 
   this.stdout = server.stdout;
   this.stdin = server.stdin;
+
+  if (verbose) {
+    server.stdout.on('data', function(data) {
+      console.log(data.toString());
+    });
+    server.stderr.on('data', function(data) {
+      console.error(data.toString());
+    });
+  }
 
   return new RSVP.Promise(function(resolve, reject) {
 


### PR DESCRIPTION
Adds `--watch` option which triggers reload on changes within `distPath`
Fixes cli-test leaving server alive when there is an exception
Only spawns one watcher (`if cluster.isMaster`)
Debounces watcher events

Inspired by https://github.com/ember-cli/ember-cli/blob/64f5a90/lib/models/server-watcher.js