### PR TITLE
Add FastBootResponse Helper

### DIFF
--- a/lib/ember-app.js
+++ b/lib/ember-app.js
@@ -93,7 +93,7 @@ EmberApp.prototype.visit = function(path, options) {
         return instance;
       });
     })
-    .then(serializeHTML(doc, rootElement));
+    .then(serializeResponse(doc, rootElement));
 };
 
 /*
@@ -125,12 +125,19 @@ function registerFastBootInfo(req, res, hostWhitelist) {
 }
 
 /*
- * After the ApplicationInstance has finished rendering, serializes the
- * resulting DOM element into HTML to be transmitted back to the user agent.
+ * After the ApplicationInstance has finished rendering:
+ *
+ *  1. Serialize the content to be injected into <head>
+ *  2. Serialize the content to be injected into <body>
+ *  3. Add response status code
+ *  4. Add response headers
+ *
+ * for transmission back to user agent.
  */
-function serializeHTML(doc, rootElement) {
+function serializeResponse(doc, rootElement) {
   return function(instance) {
     var head;
+    var response  = instance.lookup('info:-fastboot').response;
 
     if (doc.head) {
       head = HTMLSerializer.serializeChildren(doc.head);
@@ -139,9 +146,13 @@ function serializeHTML(doc, rootElement) {
     try {
       return {
         url: instance.getURL(), // TODO: use this to determine whether to 200 or redirect
-        title: doc.title,
-        head: head,
-        body: HTMLSerializer.serializeChildren(rootElement)
+        headers: response.headers,
+        statusCode: response.statusCode,
+        contentFor: {
+          title: doc.title,
+          head: head,
+          body: HTMLSerializer.serializeChildren(rootElement)
+        }
       };
     } finally {
       instance.destroy();

--- a/lib/fastboot-info.js
+++ b/lib/fastboot-info.js
@@ -1,5 +1,6 @@
 var RSVP = require('rsvp');
 var FastBootRequest = require('./fastboot-request');
+var FastBootResponse = require('./fastboot-response')
 
 /*
  * A class that encapsulates information about the
@@ -7,9 +8,9 @@ var FastBootRequest = require('./fastboot-request');
  * on to the FastBoot service.
  */
 function FastBootInfo(request, response, hostWhitelist) {
-  this.response = response;
   this.deferredPromise = RSVP.resolve();
   this.request = new FastBootRequest(request, hostWhitelist);
+  this.response = new FastBootResponse(response);
 }
 
 FastBootInfo.prototype.deferRendering = function(promise) {

--- a/lib/fastboot-response.js
+++ b/lib/fastboot-response.js
@@ -1,0 +1,9 @@
+var cookie = require('cookie');
+var FastBootHeaders = require('./fastboot-headers');
+
+function FastbootResponse(response) {
+  this.headers = new FastBootHeaders(response.headers);
+  this.statusCode = 200;
+}
+
+module.exports = FastbootResponse;

--- a/lib/server.js
+++ b/lib/server.js
@@ -86,8 +86,16 @@ FastBootServer.prototype.insertIntoIndexHTML = function(title, body, head) {
 };
 
 FastBootServer.prototype.handleSuccess = function(res, path, result, startTime) {
-  this.log(200, 'OK ' + path, startTime);
-  res.send(this.insertIntoIndexHTML(result.title, result.body, result.head));
+  var contentFor = result.contentFor;
+  var headers = result.headers;
+
+  this.log(result.statusCode, 'OK ' + path, startTime);
+
+  for (var pair of headers.entries()) {
+    res.set(pair[0], pair[1]);
+  }
+  res.status(result.statusCode);
+  res.send(this.insertIntoIndexHTML(contentFor.title, contentFor.body, contentFor.head));
 };
 
 FastBootServer.prototype.handleFailure = function(res, path, error, startTime) {

--- a/test/fastboot-info-test.js
+++ b/test/fastboot-info-test.js
@@ -1,11 +1,17 @@
 var expect = require('chai').expect;
 var path = require('path');
 var FastBootInfo = require('../lib/fastboot-info.js');
+var FastBootResponse = require('../lib/fastboot-response.js');
+var FastBootRequest = require('../lib/fastboot-request.js');
 
 describe("FastBootInfo", function() {
-  it("has a FastBootRequest", function() {
-    var response = {};
-    var request = {
+  var response;
+  var request;
+  var fastbootInfo;
+
+  beforeEach(function () {
+    response = {};
+    request = {
       cookie: "",
       protocol: "http",
       headers: {
@@ -14,9 +20,16 @@ describe("FastBootInfo", function() {
         return this.cookie;
       }
     };
-    var fastbootInfo = new FastBootInfo(request, response);
 
-    expect(fastbootInfo.request.protocol).to.equal("http");
+    fastbootInfo = new FastBootInfo(request, response);
+  });
+
+  it("has a FastBootRequest", function() {
+    expect(fastbootInfo.request).to.be.an.instanceOf(FastBootRequest);
+  });
+
+  it("has a FastBootResponse", function() {
+    expect(fastbootInfo.response).to.be.an.instanceOf(FastBootResponse);
   });
 });
 

--- a/test/fastboot-response-test.js
+++ b/test/fastboot-response-test.js
@@ -1,0 +1,47 @@
+var expect = require('chai').expect;
+var path = require('path');
+var FastBootHeaders = require('../lib/fastboot-headers.js');
+var FastBootResponse = require('../lib/fastboot-response.js');
+
+describe("FastBootResponse", function() {
+  var fastBootResponse;
+
+  beforeEach(function () {
+    var mockResponse = {
+      headers: {
+        "i-am-a": "mock header, me too"
+      },
+      get: function () {
+        return this.headers.cookie;
+      }
+    }
+
+    fastBootResponse = new FastBootResponse(mockResponse);
+  });
+
+  describe("headers", function () {
+    it("should have headers", function () {
+      expect(fastBootResponse).to.have.ownProperty("headers");
+    });
+
+    it("should be an instance of FastBootHeaders", function () {
+      expect(fastBootResponse.headers).to.be.an.instanceOf(FastBootHeaders);
+    });
+
+    it("should contain the original response's headers", function () {
+      var header = fastBootResponse.headers.getAll("i-am-a");
+      expect(header).to.deep.equal(["mock header", "me too"]);
+    });
+  });
+
+  describe("statusCode", function () {
+    it("should have a statusCode", function () {
+      expect(fastBootResponse).to.have.ownProperty("statusCode");
+    });
+
+    it("should default to 200", function () {
+      expect(fastBootResponse.statusCode).to.equal(200);
+    });
+  });
+});
+


### PR DESCRIPTION
@danmcclain and I were working on getting a `FastBootResponse` helper similar to the `FastBootRequest` one.

This basic one allows the Ember application instance access to the status code and headers.

//CC @marcoow (This is will become the official API we can use to write cookies to the response with ember-cookies).