### PR TITLE
Update Node version matrix in Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - "4.1"
-  - "4.0"
+  - "stable"
+  - "4"
   - "0.12"
-  - "0.11"
+  
 env:
   - CXX=g++-4.8 WORKER_COUNT=2
 addons:

--- a/test/fastboot-server-test.js
+++ b/test/fastboot-server-test.js
@@ -39,7 +39,8 @@ describe("FastBootServer", function() {
     var distPath = fixture('basic-app');
 
     var server = new TestHTTPServer({
-      distPath: distPath
+      distPath: distPath,
+      port: 0
     });
 
     var promise = server.start()


### PR DESCRIPTION
Node 0.11 should not be supported, and we should test against current stable version.