### PR TITLE
Fix FastBoot require

### DIFF
--- a/lib/ember-app.js
+++ b/lib/ember-app.js
@@ -3,6 +3,7 @@ var path = require('path');
 
 var SimpleDOM = require('simple-dom');
 var najax = require('najax');
+var existsSync = require('exists-sync');
 var debug   = require('debug')('ember-cli-fastboot:ember-app');
 var FastBootInfo = require('./fastboot-info');
 var VMSandbox = require('./sandboxes/vm');
@@ -153,7 +154,13 @@ function serializeHTML(doc, rootElement) {
 function buildWhitelistedRequire(whitelist, distPath) {
   return function(moduleName) {
     if (whitelist.indexOf(moduleName) > -1) {
-      return require(path.join(distPath, 'node_modules', moduleName));
+      var nodeModulesPath = path.join(distPath, 'node_modules', moduleName);
+      if (existsSync(nodeModulesPath)) {
+        return require(nodeModulesPath);
+      } else {
+        // Assume its a built in module
+        return require(moduleName);
+      }
     } else {
       throw new Error("Unable to require module '" + moduleName + "' because it was not in the whitelist.");
     }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "chalk": "^0.5.1",
     "cookie": "^0.2.3",
     "debug": "^2.1.0",
+    "exists-sync": "0.0.3",
     "express": "^4.13.3",
     "express-cluster": "0.0.4",
     "glob": "^4.0.5",


### PR DESCRIPTION
FastBoot.require assumed that the package was a npm module, this
attempts to load the built in module before checking node_modules